### PR TITLE
Fix Python 3.13/3.14 CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out repository
@@ -54,7 +55,7 @@ jobs:
         run: mdtopdf doctor --json
 
       - name: Run tests
-        run: python -m pytest tests/ -q
+        run: timeout 300s python -m pytest tests/ -vv -s -o faulthandler_timeout=120
 
   package:
     name: Package check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,8 @@ jobs:
         run: mdtopdf doctor --json
 
       - name: Run tests
-        run: timeout 300s python -m pytest tests/ -vv -s -o faulthandler_timeout=120
+        timeout-minutes: 5
+        run: python -m pytest tests/ -q
 
   package:
     name: Package check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: Check out repository

--- a/mdtopdf/core/katex.py
+++ b/mdtopdf/core/katex.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from functools import lru_cache
+import atexit
 from importlib import resources
 import re
-import threading
+from threading import RLock
 from typing import Any
 
 
-_CONTEXT_LOCK = threading.Lock()
+_CONTEXT_LOCK = RLock()
+_CONTEXT: Any | None = None
 
 
 def render_katex_to_html(content: str, *, display: str = "inline") -> str:
@@ -39,17 +40,36 @@ def load_katex_css() -> str:
     return css
 
 
-@lru_cache(maxsize=1)
 def _katex_context() -> Any:
+    global _CONTEXT
+    if _CONTEXT is not None:
+        return _CONTEXT
+
     from py_mini_racer import MiniRacer
 
     ctx = MiniRacer()
     ctx.eval("var window = this; var self = this; var global = this;")
     ctx.eval(_resource_text("dist/katex.min.js"))
     ctx.eval(_resource_text("dist/contrib/mhchem.min.js"))
-    return ctx
+    _CONTEXT = ctx
+    return _CONTEXT
+
+
+def close_katex_context() -> None:
+    global _CONTEXT
+    with _CONTEXT_LOCK:
+        ctx = _CONTEXT
+        _CONTEXT = None
+        if ctx is None:
+            return
+        close = getattr(ctx, "close", None)
+        if callable(close):
+            close()
 
 
 def _resource_text(relative_path: str) -> str:
     path = resources.files("mdtopdf").joinpath("vendor", "katex", *relative_path.split("/"))
     return path.read_text(encoding="utf-8")
+
+
+atexit.register(close_katex_context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Documentation",
   "Topic :: Printing",
   "Topic :: Text Processing :: Markup :: Markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Documentation",
   "Topic :: Printing",
   "Topic :: Text Processing :: Markup :: Markdown",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib
+import sys
+import types
 from urllib.parse import quote
 
 import pytest
 
 from mdtopdf import markdown_to_html
 from mdtopdf.core import doctor
+from mdtopdf.core import katex as katex_core
 from mdtopdf.core import markdown as markdown_core
 from mdtopdf.core import mermaid as mermaid_core
 from mdtopdf.core.html import convert_markdown_file_to_html, derive_html_output_path
@@ -297,6 +300,37 @@ def test_katex_css_rewrites_font_urls_to_package_files():
     assert "@font-face" in css
     assert "file:///" in css
     assert "url(fonts/" not in css
+
+
+def test_katex_context_can_be_closed(monkeypatch):
+    katex_core.close_katex_context()
+
+    class FakeMiniRacer:
+        def __init__(self):
+            self.closed = 0
+
+        def eval(self, source: str) -> None:
+            assert isinstance(source, str)
+
+        def call(self, name: str, latex: str, options: dict[str, object]) -> str:
+            assert name == "katex.renderToString"
+            assert latex == "x"
+            assert options["output"] == "html"
+            return "<span>x</span>"
+
+        def close(self) -> None:
+            self.closed += 1
+
+    fake = FakeMiniRacer()
+    monkeypatch.setitem(sys.modules, "py_mini_racer", types.SimpleNamespace(MiniRacer=lambda: fake))
+    monkeypatch.setattr(katex_core, "_resource_text", lambda relative_path: "")
+
+    assert katex_core.render_katex_to_html("x") == "<span>x</span>"
+
+    katex_core.close_katex_context()
+    katex_core.close_katex_context()
+
+    assert fake.closed == 1
 
 
 def test_latex_to_html_math_falls_back_to_svg_when_katex_fails(monkeypatch):


### PR DESCRIPTION
## Summary

- Close the cached KaTeX MiniRacer context on process exit so CLI subprocesses do not hang on Python 3.13+
- Restore Python 3.13 CI coverage and classifier
- Add Python 3.14 CI coverage and classifier
- Add a regression test for closing the KaTeX context

## Validation

- Local: py -m pytest tests\\ -q
- Local: py -m build
- Local: py -m twine check dist\\*
- GitHub Actions workflow_dispatch on feature/ci-python313 passed for Python 3.10, 3.11, 3.12, 3.13, 3.14