### PR TITLE
Harden release readiness checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,17 @@ concurrency:
 
 jobs:
   test:
-    name: Release tests
+    name: Release tests / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
 
     steps:
       - name: Check out repository
@@ -37,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install package
@@ -49,6 +58,7 @@ jobs:
         run: mdtopdf doctor --json
 
       - name: Run tests
+        timeout-minutes: 5
         run: python -m pytest tests/ -q
 
   build:

--- a/README_CN.md
+++ b/README_CN.md
@@ -213,7 +213,7 @@ markdown_file_to_pdf("report.md", output_path="report.pdf", overwrite=True)
 - `$inline$`、`$$block$$` 和常见 `amsmath` 环境
 - 本地 `mmdc` 可用时渲染 Mermaid 图
 
-默认不会放行任意原始 HTML。可信本地 Markdown 可以使用 `--unsafe-html`。
+默认情况下，`mdtopdf` 不会直接渲染任意原始 HTML；如果 Markdown 来源可信，可以显式加上 `--unsafe-html`。
 
 ## Mermaid 可选依赖
 


### PR DESCRIPTION
## Summary
- run release tests across Python 3.10-3.14 before publishing
- add a timeout to release test runs, matching the CI safeguard
- polish the Chinese unsafe HTML wording without merging the stale docs branch

## Verification
- py -m pytest tests\ -q
- py -m build
- py -m twine check dist\*
- clean wheel install smoke test: mdtopdf --version, mdtopdf -h, mdtopdf doctor --json
- example PDF smoke tests for examples/visual-test-en.md and examples/visual-test-cn.md