### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-markdown-pdf"
-version = "0.1.0"
+version = "0.1.1"
 description = "Agent-friendly Markdown-to-PDF CLI with HTML preview and JSON diagnostics"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump package version from `0.1.0` to `0.1.1`
- prepare patch release for README, MIT license, badge, and bundled skill updates already merged on `main`

## Validation

- `py -m pytest tests\ -q`
- `py -m build`
- `py -m twine check dist\*`
- checked built wheel metadata: `Version: 0.1.1`, `License-Expression: MIT`, `Requires-Python: >=3.10`
- `git diff --check`