### PR TITLE
Fix CLI version reporting for 0.1.2

### DIFF
--- a/mdtopdf/__init__.py
+++ b/mdtopdf/__init__.py
@@ -7,6 +7,17 @@ file-based PDF conversion. The public helpers use the same rendering path as the
 ``mdtopdf`` command.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError:  # pragma: no cover - installed wheels use metadata
+        tomllib = None  # type: ignore[assignment]
+
 from mdtopdf.api import (
     markdown_file_to_html,
     markdown_file_to_pdf,
@@ -18,7 +29,21 @@ from mdtopdf.core.html import convert_markdown_file_to_html, derive_html_output_
 from mdtopdf.core.markdown import RenderedHTML, available_themes
 from mdtopdf.core.pdf import convert_markdown_file, derive_output_path
 
-__version__ = "0.1.0"
+
+def _read_version() -> str:
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if tomllib is not None and pyproject.exists():
+        try:
+            return tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+        except (KeyError, tomllib.TOMLDecodeError):
+            pass
+    try:
+        return version("agent-markdown-pdf")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = _read_version()
 
 __all__ = [
     "RenderedHTML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-markdown-pdf"
-version = "0.1.1"
+version = "0.1.2"
 description = "Agent-friendly Markdown-to-PDF CLI with HTML preview and JSON diagnostics"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_full_e2e.py
+++ b/tests/test_full_e2e.py
@@ -5,8 +5,14 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
-from mdtopdf import markdown_file_to_html, markdown_file_to_pdf, markdown_to_pdf
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+from mdtopdf import __version__, markdown_file_to_html, markdown_file_to_pdf, markdown_to_pdf
 from mdtopdf.core.pdf import convert_markdown_file
 
 
@@ -64,6 +70,13 @@ def _assert_html(path):
     text = path.read_text(encoding="utf-8")
     assert text.startswith("<!doctype html>")
     assert '<main class="document">' in text
+
+
+def test_package_version_matches_pyproject():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    expected = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
+
+    assert __version__ == expected
 
 
 def test_python_api_generates_real_pdf(tmp_path):
@@ -154,6 +167,10 @@ class TestMdtopdfCli:
     def test_help(self):
         result = self._run(["--help"])
         assert "Convert Markdown files to themed PDFs" in result.stdout
+
+    def test_version(self):
+        result = self._run(["--version"])
+        assert __version__ in result.stdout
 
     def test_cli_convert_json(self, tmp_path):
         source = tmp_path / "report.md"


### PR DESCRIPTION
## Summary

- bump package version to `0.1.2`
- derive `mdtopdf.__version__` from the source `pyproject.toml` during local development and package metadata after installation
- add tests so `mdtopdf --version` stays aligned with the package version

## Why

`0.1.1` was published successfully, but post-release verification found that `mdtopdf --version` still reported `0.1.0` because `__version__` was hardcoded.

## Validation

- `py -m mdtopdf --version` -> `mdtopdf, version 0.1.2`
- `py -m pytest tests\ -q`
- `py -m build`
- `py -m twine check dist\*`
- checked built wheel metadata: `Version: 0.1.2`, `License-Expression: MIT`, `Requires-Python: >=3.10`
- `git diff --check`